### PR TITLE
chore: replace links to Discord with Vaadin Forum

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -125,7 +125,7 @@ Plugins and add-ons for easy integration with 3rd party development tools.
 <tr>
   <td width="50%">
 
-  [**Chat on Discord**](https://discord.gg/MYFq5RTbBn)  
+  [**Vaadin Forum**](https://vaadin.com/forum)  
   Get help and discuss with community members
   </td>
   <td width="50%">


### PR DESCRIPTION
Remove links to Discord and point to Vaadin forum instead.
